### PR TITLE
Implement Google Maps geocoding API service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in the values before running the server.
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+# Optional: change the port the HTTP server listens on.
+PORT=8080

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# apigo
+# API de Geocodificação em Go
+
+Esta API em Go expõe um endpoint REST para converter endereços em coordenadas de latitude e longitude utilizando o Google Maps Geocoding API. O projeto prioriza desempenho por meio de cache em memória e configurações de servidor HTTP otimizadas.
+
+## Requisitos
+
+- Go 1.21+
+- Conta no Google Cloud com o Geocoding API habilitado
+
+## Configuração
+
+1. Instale as dependências:
+
+   ```bash
+   go mod tidy
+   ```
+
+2. Copie o arquivo `.env.example` para `.env` e configure a chave de API do Google Maps:
+
+   ```bash
+   cp .env.example .env
+   # Edite o arquivo .env e informe sua chave
+   ```
+
+   Variáveis disponíveis:
+
+   - `GOOGLE_MAPS_API_KEY` (obrigatória): chave de acesso ao Google Maps Geocoding API.
+   - `PORT` (opcional, padrão `8080`): porta HTTP que o servidor irá escutar.
+
+## Execução
+
+Inicie o servidor:
+
+```bash
+go run ./...
+```
+
+A API ficará acessível em `http://localhost:8080` (ou na porta definida em `PORT`).
+
+### Endpoints
+
+- `GET /geocode?address=<endereco>`: retorna um JSON contendo o endereço formatado, latitude, longitude e a origem da informação (`google` ou `cache`).
+- `GET /healthz`: endpoint de verificação simples que retorna o status `ok`.
+
+### Exemplo de resposta
+
+```json
+{
+  "address": "Praça da Sé - Sé, São Paulo - SP, 01001-000, Brasil",
+  "latitude": -23.5505191,
+  "longitude": -46.6333094,
+  "source": "google"
+}
+```
+
+## Observações de desempenho
+
+- Resultados de geocodificação são armazenados em cache em memória por 30 minutos, reduzindo chamadas repetidas ao Google Maps e aumentando a capacidade de atendimento simultâneo.
+- O servidor HTTP utiliza timeouts agressivos e cliente HTTP com timeout para evitar que requisições lentas degradem o serviço.
+
+## Testes
+
+Execute os testes (caso existam) com:
+
+```bash
+go test ./...
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module apigo
+
+go 1.21

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"bufio"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// Config contains application configuration sourced from environment variables.
+type Config struct {
+	GoogleAPIKey string
+	ServerPort   string
+}
+
+// LoadEnvFile loads key=value pairs from the provided file into the process environment.
+func LoadEnvFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return errors.New("invalid line in env file: " + line)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") && len(value) >= 2 {
+			value = strings.Trim(value, "\"")
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load reads environment variables to build a Config value.
+func Load() (Config, error) {
+	cfg := Config{
+		GoogleAPIKey: os.Getenv("GOOGLE_MAPS_API_KEY"),
+		ServerPort:   os.Getenv("PORT"),
+	}
+
+	if cfg.ServerPort == "" {
+		cfg.ServerPort = "8080"
+	}
+
+	if cfg.GoogleAPIKey == "" {
+		return Config{}, errors.New("GOOGLE_MAPS_API_KEY is required")
+	}
+
+	return cfg, nil
+}
+
+// LoadFromEnvFile first attempts to read an env file and ignores missing file errors.
+func LoadFromEnvFile(path string) error {
+	err := LoadEnvFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/geocode/service.go
+++ b/internal/geocode/service.go
@@ -1,0 +1,168 @@
+package geocode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrAddressRequired is returned when no address is provided.
+	ErrAddressRequired = errors.New("address is required")
+	// ErrNoResults is returned when the Google API finds no results for the address.
+	ErrNoResults = errors.New("no results found")
+)
+
+// Result represents a successful geocoding response.
+type Result struct {
+	Address   string  `json:"address"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	Source    string  `json:"source"`
+}
+
+// Service performs geocoding requests against the Google Maps Geocoding API.
+type Service struct {
+	apiKey string
+	client *http.Client
+	cache  *cache
+}
+
+// NewService creates a configured Service instance. cacheTTL determines the lifetime of cache entries.
+func NewService(apiKey string, cacheTTL time.Duration) *Service {
+	return &Service{
+		apiKey: apiKey,
+		client: &http.Client{Timeout: 5 * time.Second},
+		cache:  newCache(cacheTTL),
+	}
+}
+
+// Geocode retrieves the coordinates for an address. It will use an in-memory cache before
+// querying the Google Maps API to keep the service responsive under heavy load.
+func (s *Service) Geocode(ctx context.Context, rawAddress string) (Result, error) {
+	address := normalizeAddress(rawAddress)
+	if address == "" {
+		return Result{}, ErrAddressRequired
+	}
+
+	if result, ok := s.cache.Get(address); ok {
+		result.Source = "cache"
+		return result, nil
+	}
+
+	apiURL := fmt.Sprintf("https://maps.googleapis.com/maps/api/geocode/json?address=%s&key=%s",
+		url.QueryEscape(address), s.apiKey,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return Result{}, err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return Result{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Result{}, fmt.Errorf("google maps api returned status %d", resp.StatusCode)
+	}
+
+	var payload geocodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return Result{}, err
+	}
+
+	if payload.Status != "OK" {
+		if payload.ErrorMessage != "" {
+			return Result{}, fmt.Errorf("google maps api error: %s", payload.ErrorMessage)
+		}
+		return Result{}, fmt.Errorf("google maps api status: %s", payload.Status)
+	}
+
+	if len(payload.Results) == 0 {
+		return Result{}, ErrNoResults
+	}
+
+	top := payload.Results[0]
+	result := Result{
+		Address:   top.FormattedAddress,
+		Latitude:  top.Geometry.Location.Lat,
+		Longitude: top.Geometry.Location.Lng,
+		Source:    "google",
+	}
+
+	s.cache.Set(address, result)
+
+	return result, nil
+}
+
+func normalizeAddress(address string) string {
+	return strings.TrimSpace(strings.ToLower(address))
+}
+
+// geocodeResponse models the subset of the Google Geocoding API response that we require.
+type geocodeResponse struct {
+	Results []struct {
+		FormattedAddress string `json:"formatted_address"`
+		Geometry         struct {
+			Location struct {
+				Lat float64 `json:"lat"`
+				Lng float64 `json:"lng"`
+			} `json:"location"`
+		} `json:"geometry"`
+	} `json:"results"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"error_message"`
+}
+
+// cache is a minimal in-memory cache with TTL support used to avoid expensive API calls for repeated requests.
+type cache struct {
+	ttl   time.Duration
+	items map[string]cacheItem
+	mu    sync.RWMutex
+}
+
+type cacheItem struct {
+	value   Result
+	expires time.Time
+}
+
+func newCache(ttl time.Duration) *cache {
+	return &cache{
+		ttl:   ttl,
+		items: make(map[string]cacheItem),
+	}
+}
+
+func (c *cache) Get(key string) (Result, bool) {
+	c.mu.RLock()
+	item, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok {
+		return Result{}, false
+	}
+	if time.Now().After(item.expires) {
+		c.mu.Lock()
+		delete(c.items, key)
+		c.mu.Unlock()
+		return Result{}, false
+	}
+	return item.value, true
+}
+
+func (c *cache) Set(key string, value Result) {
+	c.mu.Lock()
+	c.items[key] = cacheItem{
+		value:   value,
+		expires: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"apigo/internal/geocode"
+)
+
+// RegisterRoutes configures the HTTP handlers for the service.
+func RegisterRoutes(mux *http.ServeMux, service *geocode.Service) {
+	mux.HandleFunc("/geocode", geocodeHandler(service))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		respondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+}
+
+func geocodeHandler(service *geocode.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			respondError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+
+		address := strings.TrimSpace(r.URL.Query().Get("address"))
+		if address == "" {
+			respondError(w, http.StatusBadRequest, "address query parameter is required")
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		defer cancel()
+
+		result, err := service.Geocode(ctx, address)
+		if err != nil {
+			switch {
+			case errors.Is(err, geocode.ErrNoResults):
+				respondError(w, http.StatusNotFound, err.Error())
+			case errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled):
+				respondError(w, http.StatusGatewayTimeout, "geocoding request timed out")
+			default:
+				respondError(w, http.StatusBadGateway, err.Error())
+			}
+			return
+		}
+
+		respondJSON(w, http.StatusOK, result)
+	}
+}
+
+func respondJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func respondError(w http.ResponseWriter, status int, message string) {
+	respondJSON(w, status, map[string]string{"error": message})
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"apigo/internal/config"
+	"apigo/internal/geocode"
+	"apigo/internal/server"
+)
+
+func main() {
+	if err := config.LoadFromEnvFile(".env"); err != nil {
+		log.Fatalf("failed to load .env file: %v", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load configuration: %v", err)
+	}
+
+	service := geocode.NewService(cfg.GoogleAPIKey, 30*time.Minute)
+
+	mux := http.NewServeMux()
+	server.RegisterRoutes(mux, service)
+
+	srv := &http.Server{
+		Addr:         ":" + cfg.ServerPort,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	log.Printf("starting server on port %s", cfg.ServerPort)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("server failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- load configuration from environment variables and optional .env file with a sample template
- add a Google Maps geocoding service with in-memory caching for repeated address lookups
- expose REST endpoints for geocoding and health checks plus updated documentation for running the API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68d3d6542e44832e8b6e5dca809403ec